### PR TITLE
Resolve Python issue

### DIFF
--- a/2.6/Python-2.6.9/CMakeLists.txt
+++ b/2.6/Python-2.6.9/CMakeLists.txt
@@ -181,9 +181,6 @@ if (NOT DARLING_NO_EXECUTABLES)
 	target_link_libraries(python26exe python26)
 	set_target_properties(python26exe PROPERTIES OUTPUT_NAME python2.6)
 
-	set(BINARY_PACKAGING_MODE ON)
-	InstallSymlink(../../System/Library/Frameworks/Python.framework/Versions/2.6/bin/python2.6 libexec/darling/usr/bin/python2.6)
-
 	install(TARGETS python26exe DESTINATION libexec/darling/System/Library/Frameworks/Python.framework/Versions/2.6/bin)
 endif(NOT DARLING_NO_EXECUTABLES)
 


### PR DESCRIPTION
Similar to darlinghq/darling-bzip2#1 issue.
```
-- Installing: /tmp/makepkg/darling-git/pkg/darling-git/usr/lib/darling/libpython26.so
CMake Error at src/external/python/2.6/Python-2.6.9/cmake_install.cmake:46 (file):
  file INSTALL cannot find
  "/tmp/makepkg/darling-git/src/darling/build/x86-64/src/external/python/2.6/Python-2.6.9/symlinks/python2.6".
Call Stack (most recent call first):
  src/cmake_install.cmake:92 (include)
  cmake_install.cmake:44 (include)
```