### PR TITLE
Move RTLD_NOW from compile-time to runtime default, so it becomes run…

### DIFF
--- a/2.6/Python-2.6.9/Lib/ctypes/__init__.py
+++ b/2.6/Python-2.6.9/Lib/ctypes/__init__.py
@@ -11,7 +11,7 @@ from _ctypes import Union, Structure, Array
 from _ctypes import _Pointer
 from _ctypes import CFuncPtr as _CFuncPtr
 from _ctypes import __version__ as _ctypes_version
-from _ctypes import RTLD_LOCAL, RTLD_GLOBAL
+from _ctypes import RTLD_LAZY, RTLD_NOW, RTLD_LOCAL, RTLD_GLOBAL
 from _ctypes import ArgumentError
 
 from struct import calcsize as _calcsize
@@ -22,7 +22,7 @@ if __version__ != _ctypes_version:
 if _os.name in ("nt", "ce"):
     from _ctypes import FormatError
 
-DEFAULT_MODE = RTLD_LOCAL
+DEFAULT_MODE = RTLD_LOCAL|RTLD_NOW
 if _os.name == "posix" and _sys.platform == "darwin":
     # On OS X 10.3, we use RTLD_GLOBAL as default mode
     # because RTLD_LOCAL does not work at least on some
@@ -30,7 +30,7 @@ if _os.name == "posix" and _sys.platform == "darwin":
     # that.
 
     if int(_os.uname()[2].split('.')[0]) < 8:
-        DEFAULT_MODE = RTLD_GLOBAL
+        DEFAULT_MODE = RTLD_GLOBAL|RTLD_NOW
 
 from _ctypes import FUNCFLAG_CDECL as _FUNCFLAG_CDECL, \
      FUNCFLAG_PYTHONAPI as _FUNCFLAG_PYTHONAPI, \

--- a/2.6/Python-2.6.9/Modules/_ctypes/_ctypes.c
+++ b/2.6/Python-2.6.9/Modules/_ctypes/_ctypes.c
@@ -5605,6 +5605,8 @@ init_ctypes(void)
 #define RTLD_GLOBAL RTLD_LOCAL
 #endif
 
+    PyModule_AddObject(m, "RTLD_LAZY", PyInt_FromLong(RTLD_LAZY));
+    PyModule_AddObject(m, "RTLD_NOW", PyInt_FromLong(RTLD_NOW));
     PyModule_AddObject(m, "RTLD_LOCAL", PyInt_FromLong(RTLD_LOCAL));
     PyModule_AddObject(m, "RTLD_GLOBAL", PyInt_FromLong(RTLD_GLOBAL));
 

--- a/2.6/Python-2.6.9/Modules/_ctypes/callproc.c
+++ b/2.6/Python-2.6.9/Modules/_ctypes/callproc.c
@@ -1402,14 +1402,13 @@ static PyObject *py_dl_open(PyObject *self, PyObject *args)
     char *name;
     void * handle;
 #ifdef RTLD_LOCAL
-    int mode = RTLD_NOW | RTLD_LOCAL;
+    int mode = RTLD_LOCAL;
 #else
     /* cygwin doesn't define RTLD_LOCAL */
-    int mode = RTLD_NOW;
+    int mode = 0;
 #endif
     if (!PyArg_ParseTuple(args, "z|i:dlopen", &name, &mode))
         return NULL;
-    mode |= RTLD_NOW;
     handle = ctypes_dlopen(name, mode);
     if (!handle) {
         char *errmsg = ctypes_dlerror();

--- a/2.7/Python-2.7.10/Lib/ctypes/__init__.py
+++ b/2.7/Python-2.7.10/Lib/ctypes/__init__.py
@@ -11,7 +11,7 @@ from _ctypes import Union, Structure, Array
 from _ctypes import _Pointer
 from _ctypes import CFuncPtr as _CFuncPtr
 from _ctypes import __version__ as _ctypes_version
-from _ctypes import RTLD_LOCAL, RTLD_GLOBAL
+from _ctypes import RTLD_LAZY, RTLD_NOW, RTLD_LOCAL, RTLD_GLOBAL
 from _ctypes import ArgumentError
 
 from struct import calcsize as _calcsize
@@ -22,7 +22,7 @@ if __version__ != _ctypes_version:
 if _os.name in ("nt", "ce"):
     from _ctypes import FormatError
 
-DEFAULT_MODE = RTLD_LOCAL
+DEFAULT_MODE = RTLD_LOCAL|RTLD_NOW
 if _os.name == "posix" and _sys.platform == "darwin":
     # On OS X 10.3, we use RTLD_GLOBAL as default mode
     # because RTLD_LOCAL does not work at least on some
@@ -30,7 +30,7 @@ if _os.name == "posix" and _sys.platform == "darwin":
     # that.
 
     if int(_os.uname()[2].split('.')[0]) < 8:
-        DEFAULT_MODE = RTLD_GLOBAL
+        DEFAULT_MODE = RTLD_GLOBAL|RTLD_NOW
 
 from _ctypes import FUNCFLAG_CDECL as _FUNCFLAG_CDECL, \
      FUNCFLAG_PYTHONAPI as _FUNCFLAG_PYTHONAPI, \

--- a/2.7/Python-2.7.10/Modules/_ctypes/_ctypes.c
+++ b/2.7/Python-2.7.10/Modules/_ctypes/_ctypes.c
@@ -5723,6 +5723,8 @@ init_ctypes(void)
 #define RTLD_GLOBAL RTLD_LOCAL
 #endif
 
+    PyModule_AddObject(m, "RTLD_LAZY", PyInt_FromLong(RTLD_LAZY));
+    PyModule_AddObject(m, "RTLD_NOW", PyInt_FromLong(RTLD_NOW));
     PyModule_AddObject(m, "RTLD_LOCAL", PyInt_FromLong(RTLD_LOCAL));
     PyModule_AddObject(m, "RTLD_GLOBAL", PyInt_FromLong(RTLD_GLOBAL));
 

--- a/2.7/Python-2.7.10/Modules/_ctypes/callproc.c
+++ b/2.7/Python-2.7.10/Modules/_ctypes/callproc.c
@@ -1418,14 +1418,13 @@ static PyObject *py_dl_open(PyObject *self, PyObject *args)
     char *name;
     void * handle;
 #ifdef RTLD_LOCAL
-    int mode = RTLD_NOW | RTLD_LOCAL;
+    int mode = RTLD_LOCAL;
 #else
     /* cygwin doesn't define RTLD_LOCAL */
-    int mode = RTLD_NOW;
+    int mode = 0;
 #endif
     if (!PyArg_ParseTuple(args, "z|i:dlopen", &name, &mode))
         return NULL;
-    mode |= RTLD_NOW;
     handle = ctypes_dlopen(name, mode);
     if (!handle) {
         char *errmsg = ctypes_dlerror();


### PR DESCRIPTION
…time-overridable

This change moves the RTLD_NOW default from compile-time in C into runtime in Python.

This is useful to allow ctypes to lazy-bind at dlopen occasionally,
i.e. for the special purpose of inspecting genuine dylib's under darling.

This change is fully backward-compatible : people who are not aware of it,
won't notice any difference - RTLD_NOW remains the default, and
ctypes defaults to try to resolve all symbols at load. What it does, is
that one can now explicitly ask for RTLD_LAZY at the python level, and
have this flag passed along directly to dlopen. This exhancement is useful
when not all symbols are resolvable, e. g. under darling when examining
genuine dylib's.